### PR TITLE
fix: [sc-969] Remapped redirects don't redirect

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -5,7 +5,14 @@ https?://www.watermarkfw.org/* https://www.watermarkfortworth.org/:splat 302
 https?://redirect.churchleadersconference.com/clc-app-link/* clc://clc/app-link/:splat 302
 https?://redirect.churchleadersconference.com/* https://www.watermarkresources.com/conferences/clc?utm_source=churchleadersconference.com 302
 
-https?://marriagehelp.org/* https://www.reengage.org/legacy/:splat 301
+https?://marriagehelp.org/* https://www.marriagehelp.org/:splat 301
+
+# These URLs are printed in reengage books.  Resources wants them updated: https://app.shortcut.com/watermark/story/969/remapped-redirects-don-t-redirect
+https?://www.marriagehelp.org/truth https://www.reengage.org/resources?query=love&utm_source=marriagehelp.org 301
+https?://www.marriagehelp.org/conflict https://www.reengage.org/resources?query=reconciliation&utm_source=marriagehelp.org 301
+https?://www.marriagehelp.org/understand https://www.reengage.org/resources?query=emotional%20intimacy&utm_source=marriagehelp.org 301
+https?://www.marriagehelp.org/completion https://www.reengage.org/resources?query=spiritual%20intimacy&utm_source=marriagehelp.org 301
+https?://www.marriagehelp.org/diligence https://www.reengage.org/resources?query=invest&utm_source=marriagehelp.org 301
 https?://www.marriagehelp.org/* https://www.reengage.org/legacy/:splat 301
 
 https?://legacy.watermark.org/* https://www.watermark.org/:splat 301

--- a/spec/request/redirects_spec.rb
+++ b/spec/request/redirects_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe('config/redirects') do
     'http://www.watermarkfw.org/abc/123.jpg' => ['https://www.watermarkfortworth.org/abc/123.jpg', 302],
 
     'https://marriagehelp.org/test/abc/123.jpg' => 'https://www.marriagehelp.org/test/abc/123.jpg',
+    'https://www.marriagehelp.org/truth' => 'https://www.reengage.org/resources?query=love&utm_source=marriagehelp.org',
     'https://www.marriagehelp.org' => 'https://www.reengage.org/legacy',
 
     'https://legacy.watermark.org/123.jpg?a=1' => 'https://www.watermark.org/123.jpg?a=1',

--- a/spec/request/redirects_spec.rb
+++ b/spec/request/redirects_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe('config/redirects') do
     'https://www.wmfw.org/test' => ['https://www.watermarkfortworth.org/test', 302],
     'http://www.watermarkfw.org/abc/123.jpg' => ['https://www.watermarkfortworth.org/abc/123.jpg', 302],
 
-    'https://marriagehelp.org/test/abc/123.jpg' => 'https://www.reengage.org/legacy/test/abc/123.jpg',
+    'https://marriagehelp.org/test/abc/123.jpg' => 'https://www.marriagehelp.org/test/abc/123.jpg',
     'https://www.marriagehelp.org' => 'https://www.reengage.org/legacy',
 
     'https://legacy.watermark.org/123.jpg?a=1' => 'https://www.watermark.org/123.jpg?a=1',


### PR DESCRIPTION
These redirects appear in printed materials and map to the `/legacy` routes in reengage.org.  Unfortunately we can't preempt those routes with contentful redirects, so changing these needs to happen in this project instead.

Story details: https://app.shortcut.com/watermark/story/969